### PR TITLE
Fetch and render rockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.10.0",
         "react-scripts": "5.0.1",
         "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.4.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-router-dom": "^6.10.0",
     "react-scripts": "5.0.1",
     "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.4.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,7 +1,37 @@
-const Missions = () => (
-  <div>
-    <h1>Missions</h1>
-  </div>
-);
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchMissions } from '../redux/missions/missionsSlice';
+
+const Missions = () => {
+  const { missions } = useSelector((state) => state.missions);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch]);
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Mission</th>
+          <th>Description</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {missions.map((mission) => (
+          <tr className="mission-list" key={mission.mission_id}>
+            <td className="mission-title">{mission.mission_name}</td>
+            <td className="mission-description">{mission.description}</td>
+            <td className="mission-button">
+              <button id={mission.mission_id} type="button">
+                Join mission
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 export default Missions;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
 import App from './App';
+import store from './redux/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
 );

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,0 +1,45 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+const initialState = {
+  missions: [],
+  missionsisLoading: false,
+  missionserror: null,
+  fetched: false,
+};
+
+const api = 'https://api.spacexdata.com/v3/missions';
+
+export const fetchMissions = createAsyncThunk(
+  'redux/fetchMissions',
+  async (_, thunkAPI) => {
+    try {
+      const response = await fetch(`${api}`);
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.response.data);
+    }
+  },
+);
+
+export const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {},
+  extraReducers: {
+    [fetchMissions.pending]: (state) => ({ ...state, missionsisLoading: true }),
+    [fetchMissions.fulfilled]: (state, action) => ({
+      ...state,
+      missions: action.payload,
+      missionsisLoading: false,
+      fetched: true,
+    }),
+    [fetchMissions.rejected]: (state, action) => ({
+      ...state,
+      missionsisLoading: false,
+      missionserror: action.payload,
+    }),
+  },
+});
+
+export default missionsSlice.reducer;


### PR DESCRIPTION
 Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
 
 Once the data are fetched, dispatch an action to store the selected data in Redux store:
 
- mission_id
- mission_name
- description

Use useSelector() Redux Hook to select the state slices and render lists of missions in corresponding routes.

Render a table with the missions' data (as per design).