### PR TITLE
Functionality for join and cancel

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,57 +1,48 @@
 {
-    "env": {
-        "browser": true,
-        "es6": true,
-        "jest": true
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest": true
+  },
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
     },
-    "parser": "@babel/eslint-parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 2018,
-        "sourceType": "module"
-    },
-    "extends": [
-        "airbnb",
-        "plugin:react/recommended",
-        "plugin:react-hooks/recommended"
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "extends": [
+    "airbnb",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "plugins": ["react"],
+  "rules": {
+    "react/jsx-filename-extension": [
+      "warn",
+      {
+        "extensions": [".js", ".jsx"]
+      }
     ],
-    "plugins": [
-        "react"
-    ],
-    "rules": {
-        "react/jsx-filename-extension": [
-            "warn",
-            {
-                "extensions": [
-                    ".js",
-                    ".jsx"
-                ]
-            }
-        ],
-        "react/react-in-jsx-scope": "off",
-        "import/no-unresolved": "off",
-        "no-shadow": "off"
-    },
-    "overrides": [
-        {
-            "files": [
-                "src/**/*Slice.js"
-            ],
-            // avoid state param assignment
-            "rules": {
-                "no-param-reassign": [
-                    "error",
-                    {
-                        "props": false
-                    }
-                ]
-            }
-        }
-    ],
-    "ignorePatterns": [
-        "dist/",
-        "build/"
-    ]
+    "react/react-in-jsx-scope": "off",
+    "import/no-unresolved": "off",
+    "no-shadow": "off",
+    "max-len": ["error", { "code": 150 }]
+  },
+  "overrides": [
+    {
+      "files": ["src/**/*Slice.js"],
+      // avoid state param assignment
+      "rules": {
+        "no-param-reassign": [
+          "error",
+          {
+            "props": false
+          }
+        ]
+      }
+    }
+  ],
+  "ignorePatterns": ["dist/", "build/"]
 }

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,13 +1,26 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { fetchMissions } from '../redux/missions/missionsSlice';
+import {
+  fetchMissions,
+  joinMission,
+  cancelMission,
+} from '../redux/missions/missionsSlice';
 
 const Missions = () => {
-  const { missions } = useSelector((state) => state.missions);
+  const { missions, fetched } = useSelector((state) => state.missions);
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(fetchMissions());
-  }, [dispatch]);
+    if (!fetched) {
+      dispatch(fetchMissions());
+    }
+  }, [dispatch, fetched]);
+
+  const reserveMission = (missionId) => {
+    dispatch(joinMission(missionId));
+  };
+  const unresMission = (missionId) => {
+    dispatch(cancelMission(missionId));
+  };
   return (
     <table>
       <thead>
@@ -23,9 +36,23 @@ const Missions = () => {
             <td className="mission-title">{mission.mission_name}</td>
             <td className="mission-description">{mission.description}</td>
             <td className="mission-button">
-              <button id={mission.mission_id} type="button">
-                Join mission
-              </button>
+              {mission.joined ? (
+                <button
+                  id={mission.mission_id}
+                  type="button"
+                  onClick={() => unresMission(mission.mission_id)}
+                >
+                  Leave Mission
+                </button>
+              ) : (
+                <button
+                  id={mission.mission_id}
+                  type="button"
+                  onClick={() => reserveMission(mission.mission_id)}
+                >
+                  Join mission
+                </button>
+              )}
             </td>
           </tr>
         ))}

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -25,7 +25,18 @@ export const fetchMissions = createAsyncThunk(
 export const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      state.missions = state.missions.map((mission) => (mission.mission_id === action.payload
+        ? { ...mission, joined: true }
+        : mission));
+    },
+    cancelMission: (state, action) => {
+      state.missions = state.missions.map((mission) => (mission.mission_id === action.payload
+        ? { ...mission, joined: false }
+        : mission));
+    },
+  },
   extraReducers: {
     [fetchMissions.pending]: (state) => ({ ...state, missionsisLoading: true }),
     [fetchMissions.fulfilled]: (state, action) => ({
@@ -42,4 +53,5 @@ export const missionsSlice = createSlice({
   },
 });
 
+export const { joinMission, cancelMission } = missionsSlice.actions;
 export default missionsSlice.reducer;


### PR DESCRIPTION
- When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. You could use a JS filter() or map() to set the value of the new state
- Follow the same logic as with the "Join mission" - but you need to set the reserved key to false.
- Dispatch these actions upon click on the corresponding buttons.